### PR TITLE
feat(network): Add retry interceptor and update API endpoint

### DIFF
--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,3 +1,4 @@
 description: This file stores settings for Dart & Flutter DevTools.
 documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
 extensions:
+  - provider: true

--- a/lib/core/module/network_module.dart
+++ b/lib/core/module/network_module.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:dio_smart_retry/dio_smart_retry.dart';
 import 'package:flutter/foundation.dart';
 import 'package:injectable/injectable.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -12,7 +13,7 @@ abstract class NetworkModule {
 
   // ignore: non_constant_identifier_names
   String get _BASE_URL => kDebugMode
-      ? 'http://localhost:3000/api'
+      ? 'https://configxleetscroll.vercel.app/api'
       : 'https://leet-scroll.vercel.app/api';
 
   @lazySingleton
@@ -23,6 +24,7 @@ abstract class NetworkModule {
 
         connectTimeout: const Duration(seconds: 5),
         receiveTimeout: const Duration(seconds: 3),
+
         headers: {
           'Content-Type': 'application/json',
           'Accept': 'application/json',
@@ -31,6 +33,7 @@ abstract class NetworkModule {
     );
     final cookieJar = CookieJar();
     dio.interceptors.add(CookieManager(cookieJar));
+    dio.interceptors.add(RetryInterceptor(dio: dio));
     dio.interceptors.add(
       InterceptorsWrapper(
         onRequest: (options, handler) async {
@@ -48,7 +51,8 @@ abstract class NetworkModule {
 
           if (token != null) {
             // Replace Authorization header with Cookie
-            options.headers['Cookie'] = 'next-auth.session-token=$token';
+            options.headers['Cookie'] =
+                '__Secure-next-auth.session-token=$token';
           }
           debugPrint('Request: ${options.method} ${options.path}');
           debugPrint('Headers: ${options.headers}');

--- a/lib/features/leaderboard/presentation/leaderboard_screen.dart
+++ b/lib/features/leaderboard/presentation/leaderboard_screen.dart
@@ -2,7 +2,6 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:google_fonts/google_fonts.dart';
-import '../../../core/injection.dart';
 import '../logic/leaderboard_cubit.dart';
 import '../logic/leaderboard_state.dart';
 
@@ -12,86 +11,83 @@ class LeaderboardScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider(
-      create: (context) => getIt<LeaderboardCubit>()..loadLeaderboard(),
-      child: Scaffold(
-        backgroundColor: const Color(0xFF1E1E1E),
-        appBar: AppBar(
-          title: Text(
-            '<Leaderboard />',
-            style: GoogleFonts.firaCode(
-              color: Colors.green,
-              fontWeight: FontWeight.bold,
-            ),
+    return Scaffold(
+      backgroundColor: const Color(0xFF1E1E1E),
+      appBar: AppBar(
+        title: Text(
+          '<Leaderboard />',
+          style: GoogleFonts.firaCode(
+            color: Colors.green,
+            fontWeight: FontWeight.bold,
           ),
-          backgroundColor: const Color(0xFF1E1E1E),
-          elevation: 0,
         ),
-        body: BlocBuilder<LeaderboardCubit, LeaderboardState>(
-          builder: (context, state) {
-            return state.when(
-              initial: () => const Center(child: CircularProgressIndicator()),
-              loading: () => const Center(child: CircularProgressIndicator()),
-              loaded: (entries) {
-                return ListView.separated(
-                  itemCount: entries.length,
-                  separatorBuilder: (context, index) =>
-                      Divider(color: Colors.grey[800]),
-                  itemBuilder: (context, index) {
-                    final entry = entries[index];
-                    return ListTile(
-                      leading: CircleAvatar(
-                        backgroundColor: _getRankColor(index),
-                        child: Text(
-                          '${index + 1}',
-                          style: TextStyle(
-                            color: _getRankTextColor(index),
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ),
-                      title: Text(
-                        entry.name ?? 'Anonymous',
-                        style: GoogleFonts.firaCode(
-                          color: Colors.white,
+        backgroundColor: const Color(0xFF1E1E1E),
+        elevation: 0,
+      ),
+      body: BlocBuilder<LeaderboardCubit, LeaderboardState>(
+        builder: (context, state) {
+          return state.when(
+            initial: () => const Center(child: CircularProgressIndicator()),
+            loading: () => const Center(child: CircularProgressIndicator()),
+            loaded: (entries) {
+              return ListView.separated(
+                itemCount: entries.length,
+                separatorBuilder: (context, index) =>
+                    Divider(color: Colors.grey[800]),
+                itemBuilder: (context, index) {
+                  final entry = entries[index];
+                  return ListTile(
+                    leading: CircleAvatar(
+                      backgroundColor: _getRankColor(index),
+                      child: Text(
+                        '${index + 1}',
+                        style: TextStyle(
+                          color: _getRankTextColor(index),
                           fontWeight: FontWeight.bold,
                         ),
                       ),
-                      subtitle: Text(
-                        'Solved: ${entry.problemsSolved}',
-                        style: GoogleFonts.firaCode(color: Colors.grey),
-                      ),
-                      trailing: Text(
-                        '${entry.score} pts',
-                        style: GoogleFonts.firaCode(
-                          color: Colors.green,
-                          fontWeight: FontWeight.bold,
-                          fontSize: 16,
-                        ),
-                      ),
-                    );
-                  },
-                );
-              },
-              error: (message) => Center(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Text(
-                      'Error: $message',
-                      style: const TextStyle(color: Colors.red),
                     ),
-                    ElevatedButton(
-                      onPressed: () =>
-                          context.read<LeaderboardCubit>().loadLeaderboard(),
-                      child: const Text('Retry'),
+                    title: Text(
+                      entry.name ?? 'Anonymous',
+                      style: GoogleFonts.firaCode(
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
-                  ],
-                ),
+                    subtitle: Text(
+                      'Solved: ${entry.problemsSolved}',
+                      style: GoogleFonts.firaCode(color: Colors.grey),
+                    ),
+                    trailing: Text(
+                      '${entry.score} pts',
+                      style: GoogleFonts.firaCode(
+                        color: Colors.green,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 16,
+                      ),
+                    ),
+                  );
+                },
+              );
+            },
+            error: (message) => Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    'Error: $message',
+                    style: const TextStyle(color: Colors.red),
+                  ),
+                  ElevatedButton(
+                    onPressed: () =>
+                        context.read<LeaderboardCubit>().loadLeaderboard(),
+                    child: const Text('Retry'),
+                  ),
+                ],
               ),
-            );
-          },
-        ),
+            ),
+          );
+        },
       ),
     );
   }
@@ -99,11 +95,11 @@ class LeaderboardScreen extends StatelessWidget {
   Color _getRankColor(int index) {
     switch (index) {
       case 0:
-        return Colors.yellow.withOpacity(0.2);
+        return Colors.yellow.withValues(alpha: 0.2);
       case 1:
-        return Colors.grey.withOpacity(0.2);
+        return Colors.grey.withValues(alpha: 0.2);
       case 2:
-        return Colors.orange.withOpacity(0.2);
+        return Colors.orange.withValues(alpha: 0.2);
       default:
         return Colors.grey[800]!;
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'features/auth/logic/auth_cubit.dart';
 
 import 'package:firebase_core/firebase_core.dart';
 
+import 'features/leaderboard/logic/leaderboard_cubit.dart';
 import 'features/profile/logic/profile_cubit.dart';
 
 void main() async {
@@ -24,7 +25,8 @@ void main() async {
     MultiBlocProvider(
       providers: [
         BlocProvider(create: (context) => getIt<AuthCubit>()..checkAuth()),
-        BlocProvider(create: (context) => getIt<ProfileCubit>()..loadProfile()),
+        BlocProvider(create: (context) => getIt<ProfileCubit>()),
+        BlocProvider(create: (context) => getIt<LeaderboardCubit>()),
       ],
       child: MyApp(),
     ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -249,6 +249,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.3.0"
+  dio_smart_retry:
+    dependency: "direct main"
+    description:
+      name: dio_smart_retry
+      sha256: c8e20da5f49289fa7dce5c9c6b5b120928e3661aefa0fa2d206ea6d93f580928
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   dio_web_adapter:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,6 +60,7 @@ dependencies:
   google_sign_in: ^7.2.0
   dio_cookie_manager: ^3.3.0
   cookie_jar: ^4.0.8
+  dio_smart_retry: ^7.0.1
 
 dependency_overrides:
   platform: ^3.1.0

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobile/core/injection.dart';
 import 'package:mobile/features/auth/logic/auth_cubit.dart';
+import 'package:mobile/features/leaderboard/logic/leaderboard_cubit.dart';
 import 'package:mobile/features/profile/logic/profile_cubit.dart';
 
 import 'package:mobile/main.dart';
@@ -21,6 +22,7 @@ void main() {
         providers: [
           BlocProvider(create: (_) => getIt<AuthCubit>()),
           BlocProvider(create: (_) => getIt<ProfileCubit>()),
+          BlocProvider(create: (_) => getIt<LeaderboardCubit>()),
         ],
         child: MyApp(),
       ),


### PR DESCRIPTION
This commit introduces a retry mechanism for network requests and updates the development API endpoint.

- **Network Module (`network_module.dart`):**
    - Adds the `dio_smart_retry` package to automatically retry failed network requests.
    - Changes the debug `_BASE_URL` from `localhost:3000` to `configxleetscroll.vercel.app`.
    - Updates the session token cookie name to `__Secure-next-auth.session-token`.

- **Dependencies (`pubspec.yaml`, `pubspec.lock`):**
    - Adds the `dio_smart_retry` dependency.

- **State Management (`main.dart`, `leaderboard_screen.dart`):**
    - Refactors `BlocProvider` setup by moving `LeaderboardCubit` to `main.dart` for a more centralized state management approach.
    - Removes the local `BlocProvider` from `LeaderboardScreen`.

- **DevTools (`devtools_options.yaml`):**
    - Enables the Provider DevTools extension.