### PR TITLE
feat(network): Add retry interceptor and update API endpoint

### DIFF
--- a/lib/features/feed/presentation/question_card.dart
+++ b/lib/features/feed/presentation/question_card.dart
@@ -103,7 +103,7 @@ class _QuestionCardState extends State<QuestionCard> {
                 decoration: BoxDecoration(
                   border: Border(
                     bottom: BorderSide(
-                      color: AppTheme.vsCodeBorder.withOpacity(0.3),
+                      color: AppTheme.vsCodeBorder.withValues(alpha: 0.3),
                       width: 1,
                     ),
                   ),
@@ -145,14 +145,18 @@ class _QuestionCardState extends State<QuestionCard> {
                               end: Alignment.bottomCenter,
                               colors: [
                                 Colors.transparent,
-                                AppTheme.vsCodeBackground.withOpacity(0.3),
+                                AppTheme.vsCodeBackground.withValues(
+                                  alpha: 0.3,
+                                ),
                               ],
                             ),
                           ),
                           child: Center(
                             child: Icon(
                               Icons.keyboard_arrow_down,
-                              color: AppTheme.draculaComment.withOpacity(0.5),
+                              color: AppTheme.draculaComment.withValues(
+                                alpha: 0.5,
+                              ),
                               size: 20,
                             ),
                           ),
@@ -181,7 +185,7 @@ class _QuestionCardState extends State<QuestionCard> {
                 decoration: BoxDecoration(
                   border: Border(
                     top: BorderSide(
-                      color: AppTheme.vsCodeBorder.withOpacity(0.3),
+                      color: AppTheme.vsCodeBorder.withValues(alpha: 0.3),
                       width: 1,
                     ),
                   ),
@@ -469,11 +473,11 @@ class _AnswerOption extends StatelessWidget {
       if (isSelected) {
         borderColor = isCorrect ? AppTheme.successColor : AppTheme.errorColor;
         backgroundColor = isCorrect
-            ? AppTheme.successColor.withOpacity(0.1)
-            : AppTheme.errorColor.withOpacity(0.1);
+            ? AppTheme.successColor.withValues(alpha: 0.1)
+            : AppTheme.errorColor.withValues(alpha: 0.1);
       } else if (isCorrectOption) {
         borderColor = AppTheme.successColor;
-        backgroundColor = AppTheme.successColor.withOpacity(0.1);
+        backgroundColor = AppTheme.successColor.withValues(alpha: 0.1);
       }
     }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -625,7 +625,7 @@ packages:
     source: hosted
     version: "1.3.0"
   markdown:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: markdown
       sha256: "935e23e1ff3bc02d390bad4d4be001208ee92cc217cb5b5a6c19bc14aaa318c1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,6 +61,7 @@ dependencies:
   dio_cookie_manager: ^3.3.0
   cookie_jar: ^4.0.8
   dio_smart_retry: ^7.0.1
+  markdown: ^7.3.0
 
 dependency_overrides:
   platform: ^3.1.0


### PR DESCRIPTION
This commit introduces a retry mechanism for network requests and updates the development API endpoint.

- **Network Module (`network_module.dart`):**
    - Adds the `dio_smart_retry` package to automatically retry failed network requests.
    - Changes the debug `_BASE_URL` from `localhost:3000` to `configxleetscroll.vercel.app`.
    - Updates the session token cookie name to `__Secure-next-auth.session-token`.

- **Dependencies (`pubspec.yaml`, `pubspec.lock`):**
    - Adds the `dio_smart_retry` dependency.

- **State Management (`main.dart`, `leaderboard_screen.dart`):**
    - Refactors `BlocProvider` setup by moving `LeaderboardCubit` to `main.dart` for a more centralized state management approach.
    - Removes the local `BlocProvider` from `LeaderboardScreen`.

- **DevTools (`devtools_options.yaml`):**
    - Enables the Provider DevTools extension.