### PR TITLE
feat(ci): Automate release and patch workflows with Shorebird

### DIFF
--- a/.github/workflows/new-release-branch.yml
+++ b/.github/workflows/new-release-branch.yml
@@ -1,0 +1,84 @@
+# .github/workflows/new-release-branch.yml
+name: New Release Branch
+
+on:
+  create:  # Triggers ONLY when a branch or tag is created
+    branches:
+      - 'release/**'  # Only for branches like release/v1.2.0, release/next, etc.
+  workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-new-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Your existing setup steps (keystore, firebase json, flutter, shorebird, etc.)
+      - name: Prepare firebase JSON
+        uses: jsdaniell/create-json@v1.2.3
+        with:
+          name: "google-services.json"
+          json: ${{ secrets.FIREBASE_ANDROID_CONFIG }}
+          dir: "android/app/"
+
+      - name: Prepare release keystore
+        run: |
+          echo "${{ secrets.BASE_64_SIGNING_KEY }}" > release_keystore.jks.asc
+          gpg -d --passphrase "${{ secrets.BASE_64_SIGNING_KEY_PASSPHRASE }}" --batch release_keystore.jks.asc > android/app/upload-keystore.jks
+
+      - name: Prepare Key Properties
+        run: |
+          echo "${{ secrets.LOCAL_PROPERTIES }}" > android/key.properties
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2.21.0
+        with:
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Setup Shorebird
+        uses: shorebirdtech/setup-shorebird@v1
+
+      - name: Bump version
+        run: |
+          dart pub global activate bump
+          NEW_VERSION=$(bump bump --patch)  # or --minor depending on your convention
+          sed -i "s/^version: .*/version: $NEW_VERSION/" pubspec.yaml
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add pubspec.yaml
+          git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
+          git tag "v$NEW_VERSION"
+          git push origin ${{ github.ref_name }} --tags
+          echo "VERSION=$NEW_VERSION" >> $GITHUB_ENV
+
+      - name: Shorebird Full Release
+        run: shorebird release android --artifact=apk
+        env:
+          SHOREBIRD_TOKEN: ${{ secrets.SHOREBIRD_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1.20.0
+        with:
+          tag: v${{ env.VERSION }}
+          name: Release v${{ env.VERSION }}
+          body: "New release from branch ${{ github.ref_name }}"
+          artifacts: build/app/outputs/flutter-apk/app-release.apk
+          allowUpdates: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload to Firebase App Distribution
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: ${{ secrets.FIREBASE_APP_ID_ANDROID }}
+          token: ${{ secrets.FIREBASE_TOKEN }}
+          file: build/app/outputs/flutter-apk/app-release.apk
+          groups: testers

--- a/.github/workflows/patch-release-branch.yml
+++ b/.github/workflows/patch-release-branch.yml
@@ -1,0 +1,78 @@
+# .github/workflows/patch-release-branch.yml
+name: Patch Release Branch
+
+on:
+  push:
+    branches:
+      - 'release/**'  # Only pushes to existing release branches
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  patch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Same setup as before
+      - name: Prepare firebase JSON
+        uses: jsdaniell/create-json@v1.2.3
+        with:
+          name: "google-services.json"
+          json: ${{ secrets.FIREBASE_ANDROID_CONFIG }}
+          dir: "android/app/"
+
+      - name: Prepare release keystore
+        run: |
+          echo "${{ secrets.BASE_64_SIGNING_KEY }}" > release_keystore.jks.asc
+          gpg -d --passphrase "${{ secrets.BASE_64_SIGNING_KEY_PASSPHRASE }}" --batch release_keystore.jks.asc > android/app/upload-keystore.jks
+
+      - name: Prepare Key Properties
+        run: |
+          echo "${{ secrets.LOCAL_PROPERTIES }}" > android/key.properties
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2.21.0
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Setup Shorebird
+        uses: shorebirdtech/setup-shorebird@v1
+
+      - name: Change detection (only lib changes allowed for patch)
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            lib:
+              - 'lib/**'
+            forbidden:
+              - 'android/**'
+              - 'pubspec.yaml'
+              - 'shorebird.yaml'
+
+      - name: Shorebird Patch (only if pure Dart changes)
+        if: steps.filter.outputs.lib == 'true' && steps.filter.outputs.forbidden == 'false'
+        run: shorebird patch android --artifact=apk
+        env:
+          SHOREBIRD_TOKEN: ${{ secrets.SHOREBIRD_TOKEN }}
+
+      - name: Fail if non-lib changes (optional safety)
+        if: steps.filter.outputs.forbidden == 'true'
+        run: |
+          echo "Error: Changes in android/, pubspec.yaml or shorebird.yaml detected."
+          echo "Patches are only allowed for lib/ changes. Create a new release branch instead."
+          exit 1
+
+      - name: Upload Patch APK to Firebase
+        if: steps.filter.outputs.lib == 'true' && steps.filter.outputs.forbidden == 'false'
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: ${{ secrets.FIREBASE_APP_ID_ANDROID }}
+          token: ${{ secrets.FIREBASE_TOKEN }}
+          file: build/app/outputs/flutter-apk/app-release.apk
+          groups: testers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,99 +1,84 @@
-name: Release
+# .github/workflows/merge-to-main.yml
+name: Merge to Main - Branch Decision
+
 on:
   push:
-    branches: [main]
-    # Optional: Also trigger on tags for versioned releases
-    tags: ['v*']
-permissions:
-  contents: write
-
+    branches: [ main ]
+  workflow_dispatch:
 jobs:
-  build-and-release:
+  decide-branch:
+    runs-on: ubuntu-latest
+    outputs:
+      only_lib: ${{ steps.detect.outputs.only_lib }}
+      latest_release_branch: ${{ steps.latest.outputs.branch }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changes
+        uses: dorny/paths-filter@v3
+        id: detect
+        with:
+          filters: |
+            lib:
+              - 'lib/**'
+            forbidden:
+              - 'android/**'
+              - 'pubspec.yaml'
+              - 'shorebird.yaml'
+
+      - name: Set only_lib output
+        id: set
+        run: |
+          if [[ ${{ steps.detect.outputs.lib }} == 'true' && ${{ steps.detect.outputs.forbidden }} == 'false' ]]; then
+            echo "only_lib=true"
+          else
+            echo "only_lib=false"
+          fi >> $GITHUB_OUTPUT
+
+      - name: Find latest release branch
+        id: latest
+        run: |
+          # Get the most recent release/* branch by creation date
+          BRANCH=$(git branch -r --sort=-committerdate | grep 'origin/release/' | head -n1 | sed 's|origin/||' | xargs || echo "")
+          if [[ -z "$BRANCH" ]]; then
+            echo "No existing release branch found. Will create new one."
+            echo "branch=" >> $GITHUB_OUTPUT
+          else
+            echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          fi
+
+  push-to-existing-release:
+    needs: decide-branch
+    if: needs.decide-branch.outputs.only_lib == 'true' && needs.decide-branch.outputs.latest_release_branch != ''
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v4
 
-
-
-      - name: Prepare firebase JSON
-        uses: jsdaniell/create-json@v1.2.3
-        with:
-          name: "google-services.json"
-          json: ${{ secrets.FIREBASE_ANDROID_CONFIG }}
-          dir: "android/app/"
-
-      - name: Prepare release keystore
+      - name: Push to latest release branch
         run: |
-          echo "${{ secrets.BASE_64_SIGNING_KEY }}" > release_keystore.jks.asc
-          gpg -d --passphrase "${{ secrets.BASE_64_SIGNING_KEY_PASSPHRASE }}" --batch release_keystore.jks.asc > android/app/upload-keystore.jks
+          git push origin main:${{ needs.decide-branch.outputs.latest_release_branch }}
 
-      - name: Prepare Key Properties
+  create-new-release-branch:
+    needs: decide-branch
+    if: needs.decide-branch.outputs.only_lib == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get next version suggestion
+        id: version
         run: |
-          echo "${{ secrets.LOCAL_PROPERTIES }}" > android/key.properties
-          
-          
+          dart pub global activate bump
+          SUGGESTED=$(bump suggest)
+          BRANCH_NAME="release/v$SUGGESTED"
+          echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
+          echo "Suggested new branch: $BRANCH_NAME"
 
-      - name: Flutter FVM config action
-        id: fvm-config
-        uses: kuhnroyal/flutter-fvm-config-action@v3.1
-
-      - name: Setup Flutter 💻
-        uses: subosito/flutter-action@v2.21.0
-        id: setup-flutter
-        with:
-          flutter-version: ${{ steps.fvm-config.outputs.FLUTTER_VERSION }}
-          cache: true
-          cache-key: ${{ runner.os }}-flutter-${{ steps.fvm-config.outputs.FLUTTER_VERSION }}-${{ hashFiles('**/pubspec.lock') }}
-
-      - name: Install dependencies
-        run: flutter pub get
-
-
-
-      - name: Cache Pub 💾
-        uses: actions/cache@v4
-        with:
-          path: |
-            **/.dart_tool
-            ~/.pub-cache  # Added for fuller coverage
-          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pub-
-
-      - name: Setup Shorebird
-        uses: shorebirdtech/setup-shorebird@v1
-        with:
-          cache: true
-
-      # Optional: Verify Shorebird auth
-      - name: Verify Shorebird Setup
-        run: shorebird doctor
-        env:
-          SHOREBIRD_TOKEN: ${{ secrets.SHOREBIRD_TOKEN }}
-
-
-
-
-      - name: Build and Release with Shorebird
-        run: shorebird release android --artifact=apk  # --flavor=production
-        env:
-          SHOREBIRD_TOKEN: ${{ secrets.SHOREBIRD_TOKEN }}
-
-      - name: Get Version
-        id: get_version
+      - name: Create and push new release branch
         run: |
-          version=$(grep '^version: ' pubspec.yaml | awk '{print $2}' | sed 's/[[:space:]]//g')  # Trimmed & robust
-          echo "VERSION=$version" >> $GITHUB_ENV
-
-      - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'push'  # Conditional for tags/main
-        uses: ncipollo/release-action@v1.20.0
-        with:
-          tag: v${{ env.VERSION }}
-          name: Release v${{ env.VERSION }}
-          body: "Automated release with Shorebird support."  # Optional changelog
-          artifacts: "build/app/outputs/flutter-apk/app-release.apk"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          allowUpdates: true
-          prerelease: false  # If beta
+          git push origin main:refs/heads/${{ steps.version.outputs.branch }}


### PR DESCRIPTION
This commit introduces a more sophisticated CI/CD strategy using two new workflows for handling releases and patches, leveraging Shorebird for code push. The previous single `release.yml` is replaced by a more nuanced system.

-   **`new-release-branch.yml`**:
    -   Triggers on the creation of a `release/**` branch.
    -   Automatically bumps the patch version in `pubspec.yaml`, commits the change, and creates a corresponding git tag.
    -   Performs a full Shorebird release (`shorebird release android`).
    -   Creates a GitHub Release with the generated APK.
    -   Distributes the APK to testers via Firebase App Distribution.

-   **`patch-release-branch.yml`**:
    -   Triggers on pushes to existing `release/**` branches.
    -   Verifies that changes are confined to the `lib/` directory to ensure they are safe for a hot patch.
    -   If only `lib/` changes are detected, it executes a Shorebird patch (`shorebird patch android`).
    -   Distributes the patched APK to Firebase.
    -   Fails the workflow if changes are detected outside of the `lib/` directory.

-   **`release.yml` -> `merge-to-main.yml`**:
    -   The original `release.yml` workflow is refactored to act as a branching logic controller.
    -   When code is pushed to `main`, it determines if the changes are patch-safe (only in `lib/`).
    -   If safe, it pushes the changes to the latest existing release branch, triggering the patch workflow.
    -   If not safe, it creates a new `release/vX.Y.Z` branch, which in turn triggers the new release workflow.