### PR TITLE
feat(auth): Redesign login screen with a modern developer-centric UI

### DIFF
--- a/.github/workflows/new-release-branch.yml
+++ b/.github/workflows/new-release-branch.yml
@@ -7,10 +7,10 @@ on:
       - 'release/**'  # Only for branches like release/v1.2.0, release/next, etc.
   workflow_dispatch:
 
-  workflow_run:
-    workflows: ["Merge to Main - Branch Decision"]   # Name of the first workflow
-    types:
-      - completed
+#  workflow_run:
+#    workflows: ["Merge to Main - Branch Decision"]   # Name of the first workflow
+#    types:
+#      - completed
 
 
 permissions:

--- a/lib/features/auth/presentation/login_screen.dart
+++ b/lib/features/auth/presentation/login_screen.dart
@@ -1,9 +1,11 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:google_fonts/google_fonts.dart';
 import '../../../core/router/app_router.gr.dart';
 import '../../../core/widgets/responsive_builders/responsive_center_container.dart';
 import '../../../core/widgets/responsive_layout.dart';
+import '../../feed/presentation/styles/app_theme.dart';
 import '../logic/auth_cubit.dart';
 import '../logic/auth_state.dart';
 import 'widgets/login_form.dart';
@@ -15,6 +17,7 @@ class LoginScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: const Color(0xFF0A0A0A),
       body: BlocListener<AuthCubit, AuthState>(
         listener: (context, state) {
           state.maybeWhen(
@@ -29,23 +32,92 @@ class LoginScreen extends StatelessWidget {
             orElse: () {},
           );
         },
-        child: Center(
-          child: SingleChildScrollView(
-            padding: const EdgeInsets.all(24.0),
-            child: ResponsiveLayout(
-              mobile: const LoginForm(),
-              tablet: const ResponsiveCenterContainer(
-                maxWidth: 500,
-                child: LoginForm(),
-              ),
-              desktop: const ResponsiveCenterContainer(
-                maxWidth: 500,
-                child: LoginForm(),
+        child: Stack(
+          children: [
+            const _DotBackground(),
+            SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24.0),
+                child: Column(
+                  children: [
+                    Expanded(
+                      child: Center(
+                        child: SingleChildScrollView(
+                          child: ResponsiveLayout(
+                            mobile: const LoginForm(),
+                            tablet: const ResponsiveCenterContainer(
+                              maxWidth: 400,
+                              child: LoginForm(),
+                            ),
+                            desktop: const ResponsiveCenterContainer(
+                              maxWidth: 400,
+                              child: LoginForm(),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                    _buildFooter(),
+                  ],
+                ),
               ),
             ),
-          ),
+          ],
         ),
       ),
     );
   }
+
+  Widget _buildFooter() {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 24, top: 16),
+      child: RichText(
+        textAlign: TextAlign.center,
+        text: TextSpan(
+          style: GoogleFonts.firaCode(color: Colors.grey[600], fontSize: 11),
+          children: [
+            const TextSpan(text: "By continuing, you agree to our "),
+            const TextSpan(
+              text: "Terms",
+              style: TextStyle(decoration: TextDecoration.underline),
+            ),
+            const TextSpan(text: " & "),
+            const TextSpan(
+              text: "Privacy",
+              style: TextStyle(decoration: TextDecoration.underline),
+            ),
+            const TextSpan(text: "."),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DotBackground extends StatelessWidget {
+  const _DotBackground();
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(size: Size.infinite, painter: _DotPainter());
+  }
+}
+
+class _DotPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = AppTheme.draculaGreen.withValues(alpha: 0.1)
+      ..strokeWidth = 1.0;
+
+    const spacing = 30.0;
+    for (double x = 0; x < size.width; x += spacing) {
+      for (double y = 0; y < size.height; y += spacing) {
+        canvas.drawCircle(Offset(x, y), 1.0, paint);
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
 }

--- a/lib/features/auth/presentation/widgets/blinking_effect.dart
+++ b/lib/features/auth/presentation/widgets/blinking_effect.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../../feed/presentation/styles/app_theme.dart';
+
+class BlinkingSubtitle extends StatefulWidget {
+  const BlinkingSubtitle({super.key});
+
+  @override
+  State<BlinkingSubtitle> createState() => _BlinkingSubtitleState();
+}
+
+class _BlinkingSubtitleState extends State<BlinkingSubtitle>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 500),
+    )..repeat(reverse: true);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return RichText(
+      text: TextSpan(
+        style: GoogleFonts.firaCode(fontSize: 14, color: Colors.grey[400]),
+        children: [
+          const TextSpan(text: "Master algorithms on the go "),
+          WidgetSpan(
+            alignment: PlaceholderAlignment.middle,
+            child: FadeTransition(
+              opacity: _controller,
+              child: Text(
+                "|",
+                style: TextStyle(color: AppTheme.draculaGreen, fontSize: 14),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/widgets/email_sigin_form.dart
+++ b/lib/features/auth/presentation/widgets/email_sigin_form.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../logic/auth_cubit.dart';
+
+class EmailSigInForm extends StatefulWidget {
+  const EmailSigInForm({super.key});
+
+  @override
+  State<EmailSigInForm> createState() => _EmailSigInFormState();
+}
+
+class _EmailSigInFormState extends State<EmailSigInForm> {
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _formKey = GlobalKey<FormState>();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isLoading = context.select(
+      (AuthCubit cubit) =>
+          cubit.state.maybeWhen(loading: () => true, orElse: () => false),
+    );
+    return Form(
+      key: _formKey,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          TextFormField(
+            controller: _emailController,
+            decoration: const InputDecoration(
+              labelText: 'Email',
+              border: OutlineInputBorder(),
+              prefixIcon: Icon(Icons.email),
+            ),
+            validator: (value) {
+              if (value == null || value.isEmpty) {
+                return 'Please enter your email';
+              }
+              return null;
+            },
+          ),
+          const SizedBox(height: 16),
+          TextFormField(
+            controller: _passwordController,
+            decoration: const InputDecoration(
+              labelText: 'Password',
+              border: OutlineInputBorder(),
+              prefixIcon: Icon(Icons.lock),
+            ),
+            obscureText: true,
+            validator: (value) {
+              if (value == null || value.isEmpty) {
+                return 'Please enter your password';
+              }
+              return null;
+            },
+          ),
+          const SizedBox(height: 24),
+          ElevatedButton(
+            onPressed: onLogin(isLoading),
+            style: ElevatedButton.styleFrom(
+              padding: const EdgeInsets.symmetric(vertical: 16),
+            ),
+            child: isLoading
+                ? const CircularProgressIndicator()
+                : const Text('Login'),
+          ),
+          const SizedBox(height: 16),
+        ],
+      ),
+    );
+  }
+
+  VoidCallback? onLogin(bool isLoading) {
+    if (!isLoading) return null;
+    return () {
+      if (_formKey.currentState!.validate()) {
+        context.read<AuthCubit>().login(
+          _emailController.text,
+          _passwordController.text,
+        );
+      }
+    };
+  }
+}

--- a/lib/features/auth/presentation/widgets/login_form.dart
+++ b/lib/features/auth/presentation/widgets/login_form.dart
@@ -1,8 +1,9 @@
-import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import '../../../../core/router/app_router.gr.dart';
+import 'package:google_fonts/google_fonts.dart';
+import '../../../feed/presentation/styles/app_theme.dart';
 import '../../logic/auth_cubit.dart';
+import 'blinking_effect.dart';
 
 class LoginForm extends StatefulWidget {
   const LoginForm({super.key});
@@ -12,17 +13,6 @@ class LoginForm extends StatefulWidget {
 }
 
 class _LoginFormState extends State<LoginForm> {
-  final _emailController = TextEditingController();
-  final _passwordController = TextEditingController();
-  final _formKey = GlobalKey<FormState>();
-
-  @override
-  void dispose() {
-    _emailController.dispose();
-    _passwordController.dispose();
-    super.dispose();
-  }
-
   @override
   Widget build(BuildContext context) {
     final isLoading = context.select(
@@ -30,92 +20,146 @@ class _LoginFormState extends State<LoginForm> {
           cubit.state.maybeWhen(loading: () => true, orElse: () => false),
     );
 
-    return Form(
-      key: _formKey,
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Text(
-            'LeetScroll',
-            style: Theme.of(context).textTheme.displayMedium?.copyWith(
-              fontWeight: FontWeight.bold,
-              color: Theme.of(context).colorScheme.primary,
-            ),
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: 48),
-          TextFormField(
-            controller: _emailController,
-            decoration: const InputDecoration(
-              labelText: 'Email',
-              border: OutlineInputBorder(),
-              prefixIcon: Icon(Icons.email),
-            ),
-            validator: (value) {
-              if (value == null || value.isEmpty) {
-                return 'Please enter your email';
-              }
-              return null;
-            },
-          ),
-          const SizedBox(height: 16),
-          TextFormField(
-            controller: _passwordController,
-            decoration: const InputDecoration(
-              labelText: 'Password',
-              border: OutlineInputBorder(),
-              prefixIcon: Icon(Icons.lock),
-            ),
-            obscureText: true,
-            validator: (value) {
-              if (value == null || value.isEmpty) {
-                return 'Please enter your password';
-              }
-              return null;
-            },
-          ),
-          const SizedBox(height: 24),
-          ElevatedButton(
-            onPressed: isLoading
-                ? null
-                : () {
-                    if (_formKey.currentState!.validate()) {
-                      context.read<AuthCubit>().login(
-                        _emailController.text,
-                        _passwordController.text,
-                      );
-                    }
-                  },
-            style: ElevatedButton.styleFrom(
-              padding: const EdgeInsets.symmetric(vertical: 16),
-            ),
-            child: isLoading
-                ? const CircularProgressIndicator()
-                : const Text('Login'),
-          ),
-          const SizedBox(height: 16),
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        _buildLogo(),
+        const SizedBox(height: 32),
+        _buildTitle(),
+        const SizedBox(height: 8),
+        _buildSubtitle(),
+        const SizedBox(height: 64),
+        _buildGoogleButton(isLoading),
+        const SizedBox(height: 24),
+        _buildGuestButton(),
+      ],
+    );
+  }
 
-          // if(GoogleSignIn.instance.supportsAuthenticate())
-          OutlinedButton.icon(
-            onPressed: isLoading
-                ? null
-                : () {
-                    context.read<AuthCubit>().signInWithGoogle();
-                  },
-            icon: const Icon(Icons.g_mobiledata),
-            label: const Text('Sign in with Google'),
-            style: OutlinedButton.styleFrom(
-              padding: const EdgeInsets.symmetric(vertical: 16),
-            ),
-          ),
-
-          const SizedBox(height: 16),
-          TextButton(
-            onPressed: () => context.pushRoute(const RegisterRoute()),
-            child: const Text('Don\'t have an account? Register'),
+  Widget _buildLogo() {
+    return Container(
+      width: 100,
+      height: 100,
+      decoration: BoxDecoration(
+        color: const Color(0xFF1A1A1A),
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(
+          color: AppTheme.draculaGreen.withValues(alpha: 0.2),
+          width: 2,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: AppTheme.draculaGreen.withValues(alpha: 0.1),
+            blurRadius: 20,
+            spreadRadius: 5,
           ),
         ],
+      ),
+      child: Center(
+        child: Icon(
+          Icons.terminal_rounded,
+          size: 48,
+          color: AppTheme.draculaGreen,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTitle() {
+    return RichText(
+      text: TextSpan(
+        style: GoogleFonts.firaCode(
+          fontSize: 38,
+          fontWeight: FontWeight.bold,
+          letterSpacing: -1,
+        ),
+        children: [
+          TextSpan(
+            text: "<",
+            style: TextStyle(color: AppTheme.draculaGreen),
+          ),
+          const TextSpan(
+            text: "LeetScroll",
+            style: TextStyle(color: Colors.white),
+          ),
+          TextSpan(
+            text: "/>",
+            style: TextStyle(color: AppTheme.draculaGreen),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSubtitle() {
+    return BlinkingSubtitle();
+  }
+
+  Widget _buildGoogleButton(bool isLoading) {
+    return Container(
+      width: double.infinity,
+      height: 56,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
+        color: const Color(0xFF1A1A1A),
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(12),
+          onTap: isLoading
+              ? null
+              : () => context.read<AuthCubit>().signInWithGoogle(),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              if (isLoading)
+                const SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    valueColor: AlwaysStoppedAnimation(Colors.white),
+                  ),
+                )
+              else ...[
+                Image.network(
+                  'https://www.gstatic.com/images/branding/product/1x/gsa_512dp.png',
+                  height: 20,
+                ),
+                const SizedBox(width: 12),
+                Text(
+                  "Sign in with Google",
+                  style: GoogleFonts.inter(
+                    color: Colors.white,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildGuestButton() {
+    return TextButton(
+      onPressed: () {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text("Guest login not implemented yet")),
+        );
+      },
+      child: Text(
+        "CONTINUE AS GUEST",
+        style: GoogleFonts.firaCode(
+          color: Colors.grey[500],
+          fontSize: 12,
+          letterSpacing: 1.2,
+          fontWeight: FontWeight.bold,
+        ),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -69,11 +69,12 @@ class MyApp extends StatelessWidget {
       },
       child: MaterialApp.router(
         debugShowCheckedModeBanner: false,
-        title: 'LeetScroll-T17',
+        title: 'LeetScroll',
         theme: ThemeData(
           colorScheme: ColorScheme.fromSeed(
-            seedColor: Colors.green,
+            seedColor: Color(0xff00c950),
             brightness: Brightness.dark,
+            primary: Color(0xff00c950),
             surface: const Color(0xFF0A0A0A),
           ),
           scaffoldBackgroundColor: const Color(0xFF0A0A0A),
@@ -81,7 +82,7 @@ class MyApp extends StatelessWidget {
           textTheme: (Theme.of(context).textTheme).apply(
             bodyColor: const Color(0xFFEDEDED),
             displayColor: const Color(0xFFEDEDED),
-            fontFamily: GoogleFonts.jetBrainsMono().fontFamily,
+            fontFamily: GoogleFonts.spaceGrotesk().fontFamily,
           ),
         ),
         routerConfig: appRouter.config(navigatorObservers: () => [_observer]),

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -17,6 +17,9 @@ PODS:
   - Firebase/Crashlytics (12.4.0):
     - Firebase/CoreOnly
     - FirebaseCrashlytics (~> 12.4.0)
+  - Firebase/Messaging (12.4.0):
+    - Firebase/CoreOnly
+    - FirebaseMessaging (~> 12.4.0)
   - firebase_analytics (12.0.4):
     - firebase_core
     - FirebaseAnalytics (= 12.4.0)
@@ -32,6 +35,11 @@ PODS:
   - firebase_crashlytics (5.0.5):
     - Firebase/CoreOnly (~> 12.4.0)
     - Firebase/Crashlytics (~> 12.4.0)
+    - firebase_core
+    - FlutterMacOS
+  - firebase_messaging (16.0.4):
+    - Firebase/CoreOnly (~> 12.4.0)
+    - Firebase/Messaging (~> 12.4.0)
     - firebase_core
     - FlutterMacOS
   - FirebaseAnalytics (12.4.0):
@@ -85,6 +93,15 @@ PODS:
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/UserDefaults (~> 8.1)
     - PromisesObjC (~> 2.4)
+  - FirebaseMessaging (12.4.0):
+    - FirebaseCore (~> 12.4.0)
+    - FirebaseInstallations (~> 12.4.0)
+    - GoogleDataTransport (~> 10.1)
+    - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
+    - GoogleUtilities/Environment (~> 8.1)
+    - GoogleUtilities/Reachability (~> 8.1)
+    - GoogleUtilities/UserDefaults (~> 8.1)
+    - nanopb (~> 3.30910.0)
   - FirebaseRemoteConfigInterop (12.4.0)
   - FirebaseSessions (12.4.0):
     - FirebaseCore (~> 12.4.0)
@@ -95,6 +112,8 @@ PODS:
     - GoogleUtilities/UserDefaults (~> 8.1)
     - nanopb (~> 3.30910.0)
     - PromisesSwift (~> 2.1)
+  - flutter_local_notifications (0.0.1):
+    - FlutterMacOS
   - FlutterMacOS (1.0.0)
   - google_sign_in_ios (0.0.1):
     - Flutter
@@ -188,6 +207,8 @@ DEPENDENCIES:
   - firebase_auth (from `Flutter/ephemeral/.symlinks/plugins/firebase_auth/macos`)
   - firebase_core (from `Flutter/ephemeral/.symlinks/plugins/firebase_core/macos`)
   - firebase_crashlytics (from `Flutter/ephemeral/.symlinks/plugins/firebase_crashlytics/macos`)
+  - firebase_messaging (from `Flutter/ephemeral/.symlinks/plugins/firebase_messaging/macos`)
+  - flutter_local_notifications (from `Flutter/ephemeral/.symlinks/plugins/flutter_local_notifications/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - google_sign_in_ios (from `Flutter/ephemeral/.symlinks/plugins/google_sign_in_ios/darwin`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
@@ -208,6 +229,7 @@ SPEC REPOS:
     - FirebaseCoreInternal
     - FirebaseCrashlytics
     - FirebaseInstallations
+    - FirebaseMessaging
     - FirebaseRemoteConfigInterop
     - FirebaseSessions
     - GoogleAppMeasurement
@@ -229,6 +251,10 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/firebase_core/macos
   firebase_crashlytics:
     :path: Flutter/ephemeral/.symlinks/plugins/firebase_crashlytics/macos
+  firebase_messaging:
+    :path: Flutter/ephemeral/.symlinks/plugins/firebase_messaging/macos
+  flutter_local_notifications:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_local_notifications/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
   google_sign_in_ios:
@@ -248,6 +274,7 @@ SPEC CHECKSUMS:
   firebase_auth: f7f3fc5330acb24faf314a400d5814c91d90aaa9
   firebase_core: bab38c0ca089203d6012b1ab19d744c30923b96e
   firebase_crashlytics: 0e32be75e005d206ca70051a47426d24d64d0aee
+  firebase_messaging: 48725fd031b12c00913dd36a4295da2af36d9d90
   FirebaseAnalytics: 0fc2b20091f0ddd21bf73397cf8f0eb5346dc24f
   FirebaseAppCheckInterop: f734c802f21fe1da0837708f0f9a27218c8a4ed0
   FirebaseAuth: 4a2aed737c84114a9d9b33d11ae1b147d6b94889
@@ -257,8 +284,10 @@ SPEC CHECKSUMS:
   FirebaseCoreInternal: d7f5a043c2cd01a08103ab586587c1468047bca6
   FirebaseCrashlytics: a6ece278a837c7e88de2d9b5da0a3542f2342395
   FirebaseInstallations: ae9f4902cb5bf1d0c5eaa31ec1f4e5495a0714e2
+  FirebaseMessaging: d33971b7bb252745ea6cd31ab190d1a1df4b8ed5
   FirebaseRemoteConfigInterop: 1e31ec72b89c9924367c59bfb5ec9ab60d1d6766
   FirebaseSessions: ba7c7a7ca8696a8d540eb3fe3800fbe98c79786d
+  flutter_local_notifications: 4b427ffabf278fc6ea9484c97505e231166927a5
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   google_sign_in_ios: 4bb0e529b167cadc6ac785b6ed943c0a0a4cc1c9
   GoogleAppMeasurement: 1e718274b7e015cefd846ac1fcf7820c70dc017d


### PR DESCRIPTION
This commit transforms the login experience into a terminal-inspired interface and updates global styling and dependencies.

**Authentication & UI:**
-   **Login Screen:** Replaced the standard form-based login with a stylized layout featuring a terminal-icon logo, a "LeetScroll" title with code brackets, and a blinking cursor effect on the subtitle.
-   **Visual Enhancements:** Added a custom `_DotBackground` painter to create a grid pattern on the login screen.
-   **Google Sign-In:** Redesigned the Google authentication button with a modern, dark theme.
-   **Separation of Concerns:** Extracted the email/password form into `EmailSigInForm` and introduced a dedicated `BlinkingSubtitle` widget.
-   **App Theme:** Updated the global seed color to a specific "Dracula Green" (`0xff00c950`) and switched the primary font family from `jetBrainsMono` to `spaceGrotesk`.

**Infrastructure & Dependencies:**
-   **macOS Podfile:** Added Firebase Messaging and Flutter Local Notifications dependencies.
-   **App Config:** Hardcoded the production base URL for API requests, commenting out the local development override logic.
-   **Main Entry:** Simplified the app title to "LeetScroll".